### PR TITLE
Use a web-friendly URL in post-deploy message

### DIFF
--- a/scripts/post-deploy.js
+++ b/scripts/post-deploy.js
@@ -3,7 +3,7 @@ const utils = require('./utils');
 const config = require('./config');
 const log = require('./log');
 module.exports = function postDeploy() {
-  const expUrl = `exp://exp.host/@${config.expUsername}/${utils.readPackageJSON().name}`;
+  const expUrl = `https://expo.io/@${config.expUsername}/${utils.readPackageJSON().name}`;
   const qrUrl = `https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${expUrl}`;
   const issueUrl = `https://${config.githubUsername}:${config.githubToken}@api.github.com/repos/${config.githubOrg}/${config.githubRepo}/issues/${config.githubPullRequestId}/comments`;
 


### PR DESCRIPTION
GitHub appears to try and parse the "@" username included in the message, and hides everything past the "@" symbol entirely (potentially because my expo account username and github username are the same?):

![image](https://user-images.githubusercontent.com/103927/31976188-8cd9939a-b8fb-11e7-8c78-9d3c67e3fd40.png)

Expo does provide a hosted web link that can be linked to instead - which is probably more helpful then the `expo://` url anyways (since it's tappable and includes instructions for downloading expo, etc):

![image](https://user-images.githubusercontent.com/103927/31976194-97b3b05c-b8fb-11e7-8f0a-d51af6b74d36.png)
