### PR TITLE
Update to work with latest version of expo

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const preDeploy = require('./scripts/pre-deploy');
 const postDeploy = require('./scripts/post-deploy');
 const localExp = './node_modules/exp/bin/exp.js';
 log('Logging into Expo...');
-spawn(localExp, ['login', '-u', config.expUsername, '-p', config.expPassword], loginError => {
+spawn(localExp, ['login', '-u', config.expUsername, '-p', config.expPassword, '--non-interactive'], loginError => {
   if (loginError) {
     throw new Error('Failed to log into Expo');
   } else {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-import": "^2.2.0"
   },
   "dependencies": {
-    "exp": "^41.3.0",
+    "exp": "^42.1.0",
     "request": "^2.81.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-import": "^2.2.0"
   },
   "dependencies": {
-    "exp": "^42.2.0",
+    "exp": "^44.0.0",
     "request": "^2.81.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-import": "^2.2.0"
   },
   "dependencies": {
-    "exp": "^42.1.0",
+    "exp": "^42.2.0",
     "request": "^2.81.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-import": "^2.2.0"
   },
   "dependencies": {
-    "exp": "^36.0.0",
+    "exp": "^40.0.2",
     "request": "^2.81.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-import": "^2.2.0"
   },
   "dependencies": {
-    "exp": "^40.0.2",
+    "exp": "^41.3.0",
     "request": "^2.81.0"
   }
 }

--- a/scripts/pre-deploy.js
+++ b/scripts/pre-deploy.js
@@ -3,8 +3,10 @@ const config = require('./config');
 
 module.exports = function preDeploy() {
   const pkg = utils.readPackageJSON();
+  const name = utils.getExpPublishName(pkg.name, config.githubSourceBranch);
   const modified = Object.assign({}, pkg, {
-    name: utils.getExpPublishName(pkg.name, config.githubSourceBranch),
+    name,
+    slug: name,
     privacy: 'unlisted'
   });
 

--- a/scripts/pre-deploy.js
+++ b/scripts/pre-deploy.js
@@ -11,18 +11,18 @@ module.exports = function preDeploy() {
 
   utils.writePackageJSON(modified);
 
-  const app = utils.readAppJSON();
+  let app = utils.readAppJSON();
   if (app.expo) {
     app.expo = Object.assign({}, app.expo, {
       name,
       slug: name,
-      privacy: 'unlisted',
+      privacy: 'unlisted'
     });
   } else {
     app = Object.assign({}, app, {
       name,
       slug: name,
-      privacy: 'unlisted',
+      privacy: 'unlisted'
     });
   }
 

--- a/scripts/pre-deploy.js
+++ b/scripts/pre-deploy.js
@@ -6,9 +6,25 @@ module.exports = function preDeploy() {
   const name = utils.getExpPublishName(pkg.name, config.githubSourceBranch);
   const modified = Object.assign({}, pkg, {
     name,
-    slug: name,
     privacy: 'unlisted'
   });
 
   utils.writePackageJSON(modified);
+
+  const app = utils.readAppJSON();
+  if (app.expo) {
+    app.expo = Object.assign({}, app.expo, {
+      name,
+      slug: name,
+      privacy: 'unlisted',
+    });
+  } else {
+    app = Object.assign({}, app, {
+      name,
+      slug: name,
+      privacy: 'unlisted',
+    });
+  }
+
+  utils.writeAppJSON(app);
 };

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -25,5 +25,5 @@ module.exports = {
   readPackageJSON,
   writePackageJSON,
   readAppJSON,
-  writeAppJSON,
+  writeAppJSON
 };

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -12,8 +12,18 @@ function writePackageJSON(content) {
   fs.writeFileSync('./package.json', JSON.stringify(content, null, 2));
 }
 
+function readAppJSON() {
+  return JSON.parse(fs.readFileSync('./app.json'));
+}
+
+function writeAppJSON(content) {
+  fs.writeFileSync('./app.json', JSON.stringify(content, null, 2));
+}
+
 module.exports = {
   getExpPublishName,
   readPackageJSON,
-  writePackageJSON
+  writePackageJSON,
+  readAppJSON,
+  writeAppJSON,
 };


### PR DESCRIPTION
After expo requires `app.json` appr no longer works. This allows appr to work again.