### PR TITLE
Add release channel support to differentiate environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const config = require('./scripts/config');
 const log = require('./scripts/log');
 const preDeploy = require('./scripts/pre-deploy');
 const postDeploy = require('./scripts/post-deploy');
+const getPublishArgs = require('./scripts/get-publish-args');
 const localExp = './node_modules/exp/bin/exp.js';
 log('Logging into Expo...');
 spawn(localExp, ['login', '-u', config.expUsername, '-p', config.expPassword, '--non-interactive'], loginError => {
@@ -17,7 +18,7 @@ spawn(localExp, ['login', '-u', config.expUsername, '-p', config.expPassword, '-
   }
 
   log('Publishing project into Expo.');
-  spawn(localExp, ['publish'], publishError => {
+  spawn(localExp, getPublishArgs(), publishError => {
     if (publishError) {
       throw new Error('Failed to publish package to Expo');
     } else {

--- a/scripts/config/circle.js
+++ b/scripts/config/circle.js
@@ -6,5 +6,6 @@ module.exports = {
   githubOrg: process.env.CIRCLE_PROJECT_USERNAME,
   githubRepo: process.env.CIRCLE_PROJECT_REPONAME,
   githubSourceBranch: process.env.CIRCLE_BRANCH,
-  githubPullRequestId: (process.env.CI_PULL_REQUEST || '').split('/').slice(-1)[0]
+  githubPullRequestId: (process.env.CI_PULL_REQUEST || '').split('/').slice(-1)[0],
+  deployEnv: process.env.DEPLOY_ENV || 'production'
 };

--- a/scripts/config/default.js
+++ b/scripts/config/default.js
@@ -25,5 +25,8 @@ module.exports = {
   githubSourceBranch: process.env.GITHUB_SOURCE_BRANCH,
 
   // pull request number, e.g. 123
-  githubPullRequestId: process.env.GITHUB_PR_NUMBER
+  githubPullRequestId: process.env.GITHUB_PR_NUMBER,
+
+  // environment you want to deploy to. Defaults to production as expo expects
+  deployEnv: process.env.DEPLOY_ENV || 'production'
 };

--- a/scripts/config/travis.js
+++ b/scripts/config/travis.js
@@ -6,5 +6,6 @@ module.exports = {
   githubOrg: (process.env.TRAVIS_REPO_SLUG || '').split('/')[0],
   githubRepo: (process.env.TRAVIS_REPO_SLUG || '').split('/')[1],
   githubSourceBranch: process.env.TRAVIS_PULL_REQUEST_BRANCH,
-  githubPullRequestId: process.env.TRAVIS_PULL_REQUEST
+  githubPullRequestId: process.env.TRAVIS_PULL_REQUEST,
+  deployEnv: process.env.DEPLOY_ENV || 'production'
 };

--- a/scripts/get-publish-args.js
+++ b/scripts/get-publish-args.js
@@ -3,7 +3,8 @@ const config = require('./config');
 module.exports = function getPublishArgs() {
   const args = ['publish'];
   if (config.deployEnv !== 'production') {
-    args.push(`--release-channel ${config.deployEnv}`);
+    args.push('--release-channel');
+    args.push(`${config.deployEnv}`);
   }
   return args;
 };

--- a/scripts/get-publish-args.js
+++ b/scripts/get-publish-args.js
@@ -1,0 +1,9 @@
+const config = require('./config');
+
+module.exports = function getPublishArgs() {
+  const args = ['publish'];
+  if (config.deployEnv !== 'production') {
+    args.push(`--release-channel ${config.deployEnv}`);
+  }
+  return args;
+};


### PR DESCRIPTION
This PR adds support of release channel to be able to set different environments in CI

Reference: https://docs.expo.io/versions/latest/guides/release-channels.html 