### PR TITLE
Use Expo release channels instead of package namespacing

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const config = require('./scripts/config');
 const log = require('./scripts/log');
 const preDeploy = require('./scripts/pre-deploy');
 const postDeploy = require('./scripts/post-deploy');
+const getExpChannelName = require('./scripts/utils').getExpChannelName;
 const localExp = './node_modules/exp/bin/exp.js';
 log('Logging into Expo...');
 spawn(localExp, ['login', '-u', config.expUsername, '-p', config.expPassword, '--non-interactive'], loginError => {
@@ -17,7 +18,7 @@ spawn(localExp, ['login', '-u', config.expUsername, '-p', config.expPassword, '-
   }
 
   log('Publishing project into Expo.');
-  spawn(localExp, ['publish'], publishError => {
+  spawn(localExp, ['publish', '--release-channel', getExpChannelName()], publishError => {
     if (publishError) {
       throw new Error('Failed to publish package to Expo');
     } else {

--- a/scripts/config/circle.js
+++ b/scripts/config/circle.js
@@ -1,6 +1,8 @@
+// see documentation for each field in scripts/config/default.js
 module.exports = {
   expUsername: process.env.EXP_USERNAME,
   expPassword: process.env.EXP_PASSWORD,
+  expReleaseChannel: process.env.EXP_CHANNEL || process.env.CIRCLE_BRANCH,
   githubUsername: process.env.GITHUB_USERNAME,
   githubToken: process.env.GITHUB_TOKEN,
   githubOrg: process.env.CIRCLE_PROJECT_USERNAME,

--- a/scripts/config/default.js
+++ b/scripts/config/default.js
@@ -1,9 +1,13 @@
 module.exports = {
-  // exponent username for publishing
+  // expo username for publishing
   expUsername: process.env.EXP_USERNAME,
 
-  // exponent password for publishing
+  // expo password for publishing
   expPassword: process.env.EXP_PASSWORD,
+
+  // expo release channel name, may be configured
+  // explicitly or defaults to source branch
+  expReleaseChannel: process.env.EXP_CHANNEL || process.env.GITHUB_SOURCE_BRANCH,
 
   // github username for posting into PR
   githubUsername: process.env.GITHUB_USERNAME,
@@ -20,7 +24,7 @@ module.exports = {
   githubRepo: process.env.GITHUB_REPO,
 
   // name of the GitHub source branch - only used for generating the
-  // exponent publish name, so if this value is not available in the
+  // expo publish name, so if this value is not available in the
   // environment, use any other branch/pr-unique string here
   githubSourceBranch: process.env.GITHUB_SOURCE_BRANCH,
 

--- a/scripts/config/travis.js
+++ b/scripts/config/travis.js
@@ -1,6 +1,8 @@
+// see documentation for each field in scripts/config/default.js
 module.exports = {
   expUsername: process.env.EXP_USERNAME,
   expPassword: process.env.EXP_PASSWORD,
+  expReleaseChannel: process.env.EXP_CHANNEL || process.env.TRAVIS_PULL_REQUEST_BRANCH,
   githubUsername: process.env.GITHUB_USERNAME,
   githubToken: process.env.GITHUB_TOKEN,
   githubOrg: (process.env.TRAVIS_REPO_SLUG || '').split('/')[0],

--- a/scripts/post-deploy.js
+++ b/scripts/post-deploy.js
@@ -3,8 +3,8 @@ const utils = require('./utils');
 const config = require('./config');
 const log = require('./log');
 module.exports = function postDeploy() {
-  const expUrl = `https://expo.io/@${config.expUsername}/${utils.readPackageJSON().name}`;
-  const expUrlForQRCode = `https://exp.host/@${config.expUsername}/${utils.readPackageJSON().name}`;
+  const expUrl = `https://expo.io/@${config.expUsername}/${utils.readPackageJSON().name}?release-channel=${utils.getExpChannelName()}`;
+  const expUrlForQRCode = `https://exp.host/@${config.expUsername}/${utils.readPackageJSON().name}?release-channel=${utils.getExpChannelName()}`;
   const qrUrl = `https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${expUrlForQRCode}`;
 
   log('Exponent URL', expUrl);

--- a/scripts/pre-deploy.js
+++ b/scripts/pre-deploy.js
@@ -1,5 +1,4 @@
 const utils = require('./utils');
-const config = require('./config');
 
 module.exports = function preDeploy() {
   const pkg = utils.readPackageJSON();

--- a/scripts/pre-deploy.js
+++ b/scripts/pre-deploy.js
@@ -3,9 +3,9 @@ const config = require('./config');
 
 module.exports = function preDeploy() {
   const pkg = utils.readPackageJSON();
-  const name = utils.getExpPublishName(pkg.name, config.githubSourceBranch);
+  const name = utils.getSafeName(pkg.name);
+
   const modified = Object.assign({}, pkg, {
-    name,
     privacy: 'unlisted'
   });
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -6,7 +6,7 @@ function getSafeName(name) {
 }
 
 function getExpChannelName() {
-  return getSafeName(`${process.env.EXP_CHANNEL || config.githubSourceBranch}`);
+  return getSafeName(config.expReleaseChannel);
 }
 
 function readPackageJSON() {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,7 +1,12 @@
 const fs = require('fs');
+const config = require('./config');
 
-function getExpPublishName(packageName, branchName) {
-  return `${packageName}-${branchName}`.replace(/[^a-zA-Z0-9\\-]/, '-');
+function getSafeName(name) {
+  return `${name}`.replace(/[^a-zA-Z0-9\\-]/, '-');
+}
+
+function getExpChannelName() {
+  return getSafeName(`${process.env.EXP_CHANNEL || config.githubSourceBranch}`);
 }
 
 function readPackageJSON() {
@@ -21,7 +26,8 @@ function writeAppJSON(content) {
 }
 
 module.exports = {
-  getExpPublishName,
+  getSafeName,
+  getExpChannelName,
   readPackageJSON,
   writePackageJSON,
   readAppJSON,


### PR DESCRIPTION
- [x] use Expo Release Channels for builds

We default to `githubSourceBranch` but you can override it with an `EXP_CHANNEL` env variable if you want to target a specific channel.

closes #28 